### PR TITLE
matrix_bot_api: Return handle to child thread upon polling start

### DIFF
--- a/matrix_bot_api/matrix_bot_api.py
+++ b/matrix_bot_api/matrix_bot_api.py
@@ -73,3 +73,4 @@ class MatrixBotAPI:
     def start_polling(self):
         # Starts polling for messages
         self.client.start_listener_thread()
+        return self.client.sync_thread


### PR DESCRIPTION
By returning a thread handle to the newly created child thread, a bot
implementation may choose to simply join() the child thread instead of
suspending the main thread indefinitely by reading stdin forever.

This simplifies e.g. management by systemd services.